### PR TITLE
Update parser.py

### DIFF
--- a/pash_annotations/parser/parser.py
+++ b/pash_annotations/parser/parser.py
@@ -26,6 +26,8 @@ def parse(command) -> CommandInvocationInitial:
     i = 1
     while i < len(parsed_elements_list):
         potential_flag_or_option = parsed_elements_list[i]
+        if potential_flag_or_option == '': # empty string counts as an operand
+            break
         if potential_flag_or_option in set_of_all_flags:
             flag_name_as_string: str = dict_flag_to_primary_repr.get(potential_flag_or_option, potential_flag_or_option)
             flag: Flag = Flag(flag_name_as_string)

--- a/pash_annotations/parser/tests/test_parser_empty_str.py
+++ b/pash_annotations/parser/tests/test_parser_empty_str.py
@@ -1,0 +1,23 @@
+'''This is solely to test whether commands with the empty string as an operand
+such as echo "" function properly'''
+
+from pash_annotations.datatypes.CommandInvocationInitial import CommandInvocationInitial
+from pash_annotations.parser.parser import parse
+
+def test_empty_str_1():
+    parser_result = parse('echo ""')
+
+    args = []
+    operands = []
+    expected_result = CommandInvocationInitial("echo", args, operands)
+
+    assert expected_result == parser_result
+
+def test_empty_str_2():
+    parser_result = parse('cat ""')
+
+    args = []
+    operands = []
+    expected_result = CommandInvocationInitial("cat", args, operands)
+
+    assert expected_result == parser_result

--- a/pash_annotations/parser/tests/test_parser_empty_str.py
+++ b/pash_annotations/parser/tests/test_parser_empty_str.py
@@ -3,12 +3,13 @@ such as echo "" function properly'''
 
 from pash_annotations.datatypes.CommandInvocationInitial import CommandInvocationInitial
 from pash_annotations.parser.parser import parse
+from pash_annotations.datatypes.BasicDatatypes import Operand
 
 def test_empty_str_1():
     parser_result = parse('echo ""')
 
     args = []
-    operands = []
+    operands = [Operand("")]
     expected_result = CommandInvocationInitial("echo", args, operands)
 
     assert expected_result == parser_result
@@ -17,7 +18,7 @@ def test_empty_str_2():
     parser_result = parse('cat ""')
 
     args = []
-    operands = []
+    operands = [Operand("")]
     expected_result = CommandInvocationInitial("cat", args, operands)
 
     assert expected_result == parser_result


### PR DESCRIPTION
In the `parse` function in `parser/parser.py`, if the empty string is included in `parsed_elements_list` (which may be the case when parsing commands such as `echo ""`), the function call to `are_all_individually_flags` on line 39 will fail because once line 117 is reached (the first line of `are_all_individually_flags`), the code will attempt to access the first character of `potential_flag_or_option`, which will fail since `potential_flag_or_option` will be the empty string at this point.

I believe this slight change should fix the problem.